### PR TITLE
First cut at a Meson build to create shared and static libraries locally

### DIFF
--- a/dinotify.pc.in
+++ b/dinotify.pc.in
@@ -1,0 +1,9 @@
+prefix=@PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @NAME@
+Description: @DESCRIPTION@
+Version: @VERSION@
+Libs: @LIBS@
+Cflags: @CFLAGS@

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,49 @@
+# -*- mode: python; -*-
+
+project(
+    'dinotify',
+    'd',
+    version: '0.2.1',
+    default_options: ['buildtype=release'],
+)
+
+sources =  [
+    'source/dinotify.d',
+]
+
+shared_library(
+    meson.project_name(),
+    sources,
+    version: meson.project_version(),
+    soversion: '0',
+    install: true,
+)
+
+static_library(
+    meson.project_name(),
+    sources,
+    install: true,
+)
+
+# The pkgconfig system produces C/C++ library flags which are of
+# little use with ldc2, so must do things the hard way. :-(
+
+pc_file_data = configuration_data()
+pc_file_data.set('NAME', meson.project_name())
+pc_file_data.set('VERSION', meson.project_version())
+pc_file_data.set('DESCRIPTION', 'A tiny D library to work with Linux\'s kernel inotify file events subsystem.')
+pc_file_data.set('LIBS', '-L-L${libdir} -L-l' + meson.project_name())
+pc_file_data.set('CFLAGS', '-I${includedir}/d')
+pc_file_data.set('PREFIX', get_option('prefix'))
+pc_file = configure_file(configuration: pc_file_data, input: meson.project_name() + '.pc.in', output: meson.project_name() + '.pc')
+
+install_data(pc_file, install_dir: 'share/pkgconfig')
+
+testExecutable = executable(
+    'dinotify-test',
+    sources,
+    d_args: ['-unittest'],
+    link_args: ['--main'],
+)
+
+test('all tests', testExecutable)

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,8 @@ static_library(
     install: true,
 )
 
+install_data('source/dinotify.d', install_dir: get_option('prefix') + '/include/d')
+
 # The pkgconfig system produces C/C++ library flags which are of
 # little use with ldc2, so must do things the hard way. :-(
 


### PR DESCRIPTION
Whilst Dub is the standard path for D packages and modules, it can be very useful the get things packaged for the distributions directly. cf. GtkD. This gets shared (and static) libraries on the systems for all to use. With a view to moving toward getting someone (*) to package dinotify for Debian and Fedora, here is the beginnings of a Meson build. It seems to work for me just now.

(*) Preferably the people that package GtkD for Debian and Fedora. 