### PR TITLE
Update version number in Meson build for recent version tag.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
     'dinotify',
     'd',
-    version: '0.2.1',
+    version: '0.2.2',
     default_options: ['buildtype=release'],
 )
 


### PR DESCRIPTION
Sadly the version number is explicitly in the Meson build, so this update is needed for consistency with the Git tag.

It is not clear that picking up the version tag from the Git repository is the right approach since a distribution is a tarball.