### PR TITLE
Only make the default library: whether it is static or dynamic is a…

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ sharedlib = library(
     meson.project_name(),
     sources,
     version: meson.project_version(),
-    soversion: '0',
+    pic: true,
     install: true,
 )
 

--- a/meson.build
+++ b/meson.build
@@ -14,17 +14,11 @@ sources =  [
 
 install_headers(sources, subdir: 'd/')
 
-sharedlib = shared_library(
+sharedlib = library(
     meson.project_name(),
     sources,
     version: meson.project_version(),
     soversion: '0',
-    install: true,
-)
-
-staticlib = static_library(
-    meson.project_name(),
-    sources,
     install: true,
 )
 


### PR DESCRIPTION
…choice for the person doing the installation.

Apparently this is a more idiomatic way of using Meson for build.